### PR TITLE
Add PDF parsing with OCR fallback

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -4,23 +4,103 @@ declare(strict_types=1);
 
 namespace Coda;
 
-use Exception;
+use RuntimeException;
 
 final class Parser
 {
-    public static function fromPdf(string $path): array
+    /**
+     * Parse a PDF statement and return the operation data.
+     *
+     * @param string $path Path to the PDF file.
+     * @param \Smalot\PdfParser\Parser|null $pdfParser Optional PDF parser for testing.
+     * @param callable|null $ocr Optional OCR callback receiving image path and returning JSON text.
+     */
+    public static function fromPdf(string $path, ?\Smalot\PdfParser\Parser $pdfParser = null, ?callable $ocr = null): array
     {
-        // Placeholder logic: in real implementation we would use Smalot\PdfParser
-        // and OpenAI API to parse PDF content.
-        // Here we return a dummy structure for example purposes.
-        return [
-            'company' => 'Example SA',
-            'iban' => 'BE68539007547034',
-            'opening_balance' => 1000.00,
-            'closing_balance' => 1100.00,
-            'operations' => [
-                ['date' => '010124', 'label' => 'Paiement', 'amount' => 100.00],
+        $pdfParser = $pdfParser ?? new \Smalot\PdfParser\Parser();
+        try {
+            $document = $pdfParser->parseFile($path);
+            $text = trim($document->getText());
+        } catch (\Throwable $e) {
+            $text = '';
+        }
+
+        if ($text !== '') {
+            return self::decode($text);
+        }
+
+        if (!is_callable($ocr)) {
+            $ocr = [self::class, 'callOpenAi'];
+        }
+
+        $images = self::pdfToImages($path);
+        $result = '';
+        foreach ($images as $img) {
+            $result .= $ocr($img);
+        }
+
+        return self::decode($result);
+    }
+
+    private static function pdfToImages(string $path): array
+    {
+        if (!class_exists('\Imagick')) {
+            throw new RuntimeException('Imagick extension required for OCR path');
+        }
+        $imagick = new \Imagick();
+        $imagick->readImage($path);
+        $images = [];
+        foreach ($imagick as $page) {
+            $page->setImageFormat('png');
+            $tmp = tempnam(sys_get_temp_dir(), 'ocr') . '.png';
+            $page->writeImage($tmp);
+            $images[] = $tmp;
+        }
+        return $images;
+    }
+
+    private static function callOpenAi(string $imagePath): string
+    {
+        $ch = curl_init('https://api.openai.com/v1/chat/completions');
+        $headers = [
+            'Authorization: Bearer ' . getenv('OPENAI_API_KEY'),
+            'Content-Type: application/json',
+        ];
+        $body = [
+            'model' => 'gpt-4-vision-preview',
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'Extract bank statement data as JSON'],
+                        ['type' => 'image_url', 'image_url' => [
+                            'url' => 'data:image/png;base64,' . base64_encode(file_get_contents($imagePath)),
+                        ]],
+                    ],
+                ],
             ],
         ];
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($body),
+        ]);
+        $response = curl_exec($ch);
+        if ($response === false) {
+            throw new RuntimeException('OpenAI request failed: ' . curl_error($ch));
+        }
+        curl_close($ch);
+        $data = json_decode($response, true);
+        return $data['choices'][0]['message']['content'] ?? '';
+    }
+
+    private static function decode(string $text): array
+    {
+        $data = json_decode($text, true);
+        if (!is_array($data)) {
+            throw new RuntimeException('Unable to decode statement');
+        }
+        return $data;
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Coda\Parser;
+
+final class ParserTest extends TestCase
+{
+    public function testFromPdfText(): void
+    {
+        $expected = [
+            'iban' => 'BE11',
+            'opening_balance' => 1,
+            'closing_balance' => 2,
+            'operations' => [],
+        ];
+        $document = new class($expected) {
+            private array $data;
+            public function __construct(array $data) { $this->data = $data; }
+            public function getText(): string { return json_encode($this->data); }
+        };
+        $parser = new class($document) {
+            private $doc;
+            public function __construct($doc) { $this->doc = $doc; }
+            public function parseFile(string $path) { return $this->doc; }
+        };
+        $result = Parser::fromPdf('dummy.pdf', $parser);
+        $this->assertSame($expected, $result);
+    }
+
+    public function testFromPdfOcr(): void
+    {
+        $expected = [
+            'iban' => 'BE99',
+            'opening_balance' => 10,
+            'closing_balance' => 10,
+            'operations' => [],
+        ];
+        $document = new class {
+            public function getText(): string { return ''; }
+        };
+        $parser = new class($document) {
+            private $doc;
+            public function __construct($doc) { $this->doc = $doc; }
+            public function parseFile(string $path) { return $this->doc; }
+        };
+        $ocr = function (string $image) use ($expected): string {
+            return json_encode($expected);
+        };
+        $result = Parser::fromPdf('dummy.pdf', $parser, $ocr);
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- implement PDF parser using Smalot/PdfParser
- send images to OpenAI vision API when text can't be extracted
- expose parsing helpers and OCR callback
- add unit tests covering text and OCR paths

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `~/.composer/vendor/bin/phpcs --standard=PSR12 src` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68541f979554832c9864c035ab93528e