### PR TITLE
Improve IBAN validation and tests

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -25,9 +25,20 @@ final class Validator
     private static function checkIban(string $iban): bool
     {
         $rearranged = substr($iban, 4) . substr($iban, 0, 4);
-        $numeric = preg_replace_callback('/[A-Z]/', static function (array $match): string {
-            return (string) (ord($match[0]) - 55);
-        }, $rearranged);
-        return intval($numeric) % 97 === 1;
+        $numeric = preg_replace_callback(
+            '/[A-Z]/',
+            static function (array $match): string {
+                return (string) (ord($match[0]) - 55);
+            },
+            $rearranged
+        );
+
+        $remainder = 0;
+        $len = strlen($numeric);
+        for ($i = 0; $i < $len; $i++) {
+            $remainder = ($remainder * 10 + (int) $numeric[$i]) % 97;
+        }
+
+        return $remainder === 1;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -20,4 +20,26 @@ final class ValidatorTest extends TestCase
         Validator::check($data);
         $this->assertTrue(true);
     }
+
+    public function testInvalidCheckDigits(): void
+    {
+        $data = [
+            'iban' => 'BE68539007547035',
+            'opening_balance' => 100,
+            'closing_balance' => 100,
+            'operations' => [],
+        ];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('IBAN invalide');
+        Validator::check($data);
+    }
+
+    public function testLongIban(): void
+    {
+        $method = new \ReflectionMethod(Validator::class, 'checkIban');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, 'GB82WEST12345698765432'));
+    }
 }


### PR DESCRIPTION
## Summary
- implement a string-based mod‑97 algorithm for IBAN validation
- add tests for invalid check digits and long IBANs

## Testing
- `vendor/bin/phpunit -c phpunit.xml tests/ValidatorTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854232a3830832c893ea558401db3a4