### PR TITLE
Add upload validation and tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="lib/autoload.php" colors="true">
     <testsuites>
         <testsuite name="unit">
             <directory>tests</directory>

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coda;
+
+use RuntimeException;
+
+final class Upload
+{
+    /**
+     * Validate an uploaded file.
+     *
+     * @param array $file The $_FILES entry for the upload.
+     *
+     * @throws RuntimeException If the upload is invalid.
+     */
+    public static function validate(array $file): void
+    {
+        if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            throw new RuntimeException('Upload error');
+        }
+
+        if (($file['size'] ?? 0) > 10 * 1024 * 1024) {
+            throw new RuntimeException('File too large');
+        }
+
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        if ($finfo === false) {
+            throw new RuntimeException('Unable to open finfo');
+        }
+        $mime = finfo_file($finfo, $file['tmp_name']);
+        finfo_close($finfo);
+        if ($mime !== 'application/pdf') {
+            throw new RuntimeException('Invalid file type');
+        }
+    }
+}

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Coda\Upload;
+
+final class UploadTest extends TestCase
+{
+    public function testRejectNonPdf(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tmp, 'not a pdf');
+        $file = [
+            'name' => 'file.txt',
+            'tmp_name' => $tmp,
+            'size' => filesize($tmp),
+            'error' => UPLOAD_ERR_OK,
+        ];
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid file type');
+        Upload::validate($file);
+    }
+
+    public function testRejectLargeFile(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tmp, str_repeat('a', 10 * 1024 * 1024 + 1));
+        $file = [
+            'name' => 'file.pdf',
+            'tmp_name' => $tmp,
+            'size' => filesize($tmp),
+            'error' => UPLOAD_ERR_OK,
+        ];
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('File too large');
+        Upload::validate($file);
+    }
+}


### PR DESCRIPTION
## Summary
- validate uploaded PDF files before processing
- use lib autoloader for PHPUnit
- add Upload class with validation logic
- test validation with invalid uploads

## Testing
- `phpcs src/Upload.php`
- `phpcs routes.php`
- `phpunit` *(fails: Class "Coda\CodaBuilder" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685424872640832ca13b3c36931c0218